### PR TITLE
Should not strip trailing slash from To

### DIFF
--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -80,8 +80,8 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 	}
 	
 	public function setTo($val) {
-		$val = rtrim($val,'?');
-		if($val != '/') $val = rtrim($val,'/');
+		//$val = rtrim($val,'?');
+		//if($val != '/') $val = rtrim($val,'/');
 		$this->setField('To', strtolower($val));
 	}
 


### PR DESCRIPTION
Why are we stripping the trailing slash of the destination URL?
SilverStripe uses trailing slash for URL's and Google likes it better if we do not send mixed signals.
