### PR TITLE
BUGFIX: Fixed warning if the variable passed to RedirectedURLHandler::arrayToLowercase() is not an array

### DIFF
--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -23,7 +23,7 @@ class RedirectedURLHandler extends Extension {
 
 		foreach($vars as $k => $v) {
 			if(is_array($v)) {
-				$result[strtolower($k)] = $this->arrayToLowercase(strtolower($v));
+				$result[strtolower($k)] = $this->arrayToLowercase($v);
 			} else {
 			    $result[strtolower($k)] = strtolower($v);
             }


### PR DESCRIPTION
In some cases ``RedirectedURLHandler::arrayToLowercase()`` can get passed an argument that is not an array resulting in a warning "[Warning] Invalid argument supplied for foreach() in RedirectedURLHandler.php line 24". This pull request adds a check to ensure that the ``$vars`` argument is actually an array before attempting to iterate over the ``$vars`` argument.

I'm not exactly sure how malformed the url has to be to actually produce it I wasn't able to line up the error timestamp with the access logs. However this fix should resolve the problem by simply checking to see if the $vars argument is actually an array or not before attempting to iterate over it.