### PR TITLE
Support subsites separation

### DIFF
--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -110,7 +110,7 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 		if($querystring) $qsClause = "AND \"FromQuerystring\" = '$SQL_querystring'";
 		else $qsClause = "AND \"FromQuerystring\" IS NULL";
 
- 		return DataObject::get_one("RedirectedURL", "\"FromBase\" = '$SQL_base' $qsClause");
+ 		return RedirectedURL::get()->where("\"FromBase\" = '$SQL_base' $qsClause")->limit(1)->first();
 	}
 
 	public function providePermissions() {

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -45,7 +45,7 @@ class RedirectedURLHandler extends Extension {
 		// Assumes the base url has no trailing slash.
 		$SQL_base = Convert::raw2sql(rtrim($base, '/'));
 
-		$potentials = DataObject::get("RedirectedURL", "\"FromBase\" = '/" . $SQL_base . "'", "\"FromQuerystring\" ASC");
+		$potentials = RedirectedURL::get()->filter(array('FromBase' => '/' . $SQL_base))->sort('FromQuerystring ASC');
 		$listPotentials = new ArrayList; 
 		foreach  ($potentials as $potential){ 
 			$listPotentials->push($potential);
@@ -56,7 +56,7 @@ class RedirectedURLHandler extends Extension {
 		for ($pos = count($baseparts) - 1; $pos >= 0; $pos--){
 			$basestr = implode('/', array_slice($baseparts, 0, $pos));
 			$basepart = Convert::raw2sql($basestr . '/*');
-			$basepots = DataObject::get("RedirectedURL", "\"FromBase\" = '/" . $basepart . "'", "\"FromQuerystring\" ASC");
+			$basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring ASC');
 			foreach ($basepots as $basepot){
                 // If the To URL ends in a wildcard /*, append the remaining request URL elements
 				if (substr($basepot->To, -2) === '/*'){					


### PR DESCRIPTION
When using a module like https://github.com/adrexia/silverstripe-subsite-modeladmins or https://github.com/lekoala/silverstripe-subsites-extras and applying its extension to RedirectedURL dataobject to restrict it to a subsite, the CMS management part works fine, but the runtime part doesn't find any potential candidates.

Hence this little update to use the dataobject class name rather than the generic DataObject one.