### PR TITLE
Allow trailing slash

### DIFF
--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -78,13 +78,6 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 		$val = rtrim($val,'?');
 		$this->setField('FromQuerystring', strtolower($val));
 	}
-	
-	public function setTo($val) {
-		$val = rtrim($val,'?');
-		if($val != '/') $val = rtrim($val,'/');
-		$this->setField('To', strtolower($val));
-	}
-
 
 	/**
 	 * Helper for bulkloader {@link: RedirectedURLAdmin.getModelImporters}


### PR DESCRIPTION
The `setTo()` method forces "To" URLs to not end in a /. There appears to be no reason for this restriction.

If also using the module [axllent/silverstripe-trailing-slash](http://addons.silverstripe.org/add-ons/axllent/silverstripe-trailing-slash) then the outcome is an unnecessary double redirect.