### PR TITLE
Remove forced lower case on all fields

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,5 @@
+---
+name: silverstripe-redirectedurls
+---
+RedirectedURLHandler:
+  case_insensitive_matching: false

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,5 +1,0 @@
----
-name: silverstripe-redirectedurls
----
-RedirectedURLHandler:
-  case_insensitive_matching: false

--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -90,7 +90,7 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 		$from = rtrim($from,'?');
 
 		if(strpos($from,'?') !== false) {
-			list($base, $querystring) = explode('?', strtolower($from), 2);
+			list($base, $querystring) = explode('?', $from, 2);
 
 		} else {
 			$base = $from;

--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -71,12 +71,12 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 		if($val[0] != '/') $val = "/$val";
 		if($val != '/') $val = rtrim($val,'/');
 		$val = rtrim($val,'?');
-		$this->setField('FromBase', strtolower($val));
+		$this->setField('FromBase', $val);
 	}
 
 	public function setFromQuerystring($val) {
 		$val = rtrim($val,'?');
-		$this->setField('FromQuerystring', strtolower($val));
+		$this->setField('FromQuerystring', $val);
 	}
 
 	/**

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -83,9 +83,9 @@ class RedirectedURLHandler extends Extension {
 			$basestr = implode('/', array_slice($baseparts, 0, $pos));
 			$basepart = Convert::raw2sql($basestr . '/*');
 			$basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring ASC');
-			foreach ($basepots as $basepot){
+			foreach ($basepots as $basepot) {
 				// If the To URL ends in a wildcard /*, append the remaining request URL elements
-				if (substr($basepot->To, -2) === '/*'){
+				if (substr($basepot->To, -2) === '/*') {
 					$basepot->To = substr($basepot->To, 0, -2) . substr($base, strlen($basestr));
 				}
 				$listPotentials->push($basepot);

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -12,8 +12,8 @@
  */
 class RedirectedURLHandler extends Extension {
 	/**
-     * Whether to ignore the case of query parameters when attempting to find a RedirectedURL
-     *
+	 * Whether to ignore the case of query parameters when attempting to find a RedirectedURL
+	 *
 	 * @config
 	 * @var bool
 	 */
@@ -36,6 +36,24 @@ class RedirectedURLHandler extends Extension {
 	}
 
 	/**
+	 * Converts an array of key value pairs to lowercase
+	 *
+	 * @param array $vars key value pairs
+	 * @return array
+	 */
+	protected function arrayToLowercase($vars) {
+		$result = array();
+		foreach($vars as $k => $v) {
+			if(is_array($v)) {
+				$result[strtolower($k)] = $this->arrayToLowercase($v);
+			} else {
+				$result[strtolower($k)] = strtolower($v);
+			}
+		}
+		return $result;
+	}
+
+	/**
 	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError404($request) {
@@ -54,13 +72,13 @@ class RedirectedURLHandler extends Extension {
 		$SQL_base = Convert::raw2sql(rtrim($base, '/'));
 
 		$potentials = RedirectedURL::get()->filter(array('FromBase' => '/' . $SQL_base))->sort('FromQuerystring ASC');
-		$listPotentials = new ArrayList; 
+		$listPotentials = new ArrayList;
 		foreach ($potentials as $potential) {
 			$listPotentials->push($potential);
 		}
-		
+
 		// Find any matching FromBase elements terminating in a wildcard /*
-		$baseparts = explode('/', $base); 
+		$baseparts = explode('/', $base);
 		for ($pos = count($baseparts) - 1; $pos >= 0; $pos--) {
 			$basestr = implode('/', array_slice($baseparts, 0, $pos));
 			$basepart = Convert::raw2sql($basestr . '/*');
@@ -72,8 +90,8 @@ class RedirectedURLHandler extends Extension {
 				}
 				$listPotentials->push($basepot);
 			}
-		}	
-		
+		}
+
 		$matched = null;
 
 		// Then check the get vars, ignoring any additional get vars that

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -12,6 +12,14 @@
  */
 class RedirectedURLHandler extends Extension {
 	/**
+     * Whether to ignore the case of query parameters when attempting to find a RedirectedURL
+     *
+	 * @config
+	 * @var bool
+	 */
+	private static $case_insensitive_matching = false;
+
+	/**
 	 * Converts the case of the keys of the an array
 	 *
 	 * @param array $arr Key value pairs
@@ -31,7 +39,7 @@ class RedirectedURLHandler extends Extension {
 	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError404($request) {
-		$caseInsensitiveMatching = Config::inst()->get(get_class($this), 'case_insensitive_matching');
+		$caseInsensitiveMatching = $this->config()->get('case_insensitive_matching');
 		$base = $request->getURL();
 		$getVars = $request->getVars();
 

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -37,7 +37,7 @@ class RedirectedURLHandler extends Extension {
 
 		unset($getVars['url']);
 
-		if($caseInsensitiveMatching) {
+		if ($caseInsensitiveMatching) {
 			$getVars = $this->array_change_key_case_unicode($getVars);
 		}
 
@@ -47,13 +47,13 @@ class RedirectedURLHandler extends Extension {
 
 		$potentials = RedirectedURL::get()->filter(array('FromBase' => '/' . $SQL_base))->sort('FromQuerystring ASC');
 		$listPotentials = new ArrayList; 
-		foreach  ($potentials as $potential){ 
+		foreach ($potentials as $potential) {
 			$listPotentials->push($potential);
 		}
 		
 		// Find any matching FromBase elements terminating in a wildcard /*
 		$baseparts = explode('/', $base); 
-		for ($pos = count($baseparts) - 1; $pos >= 0; $pos--){
+		for ($pos = count($baseparts) - 1; $pos >= 0; $pos--) {
 			$basestr = implode('/', array_slice($baseparts, 0, $pos));
 			$basepart = Convert::raw2sql($basestr . '/*');
 			$basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring ASC');
@@ -70,21 +70,21 @@ class RedirectedURLHandler extends Extension {
 
 		// Then check the get vars, ignoring any additional get vars that
 		// this URL may have
-		if($listPotentials) {
-			foreach($listPotentials as $potential) {
-				$allVarsMatch = true;		
+		if ($listPotentials) {
+			foreach ($listPotentials as $potential) {
+				$allVarsMatch = true;
 
-				if($potential->FromQuerystring) {
+				if ($potential->FromQuerystring) {
 					$reqVars = array();
 					parse_str($potential->FromQuerystring, $reqVars);
-					if($caseInsensitiveMatching) {
+					if ($caseInsensitiveMatching) {
 						$reqVars = $this->array_change_key_case_unicode($reqVars);
 					}
 
-					foreach($reqVars as $k => $v) {
-						if(!$v) continue;
+					foreach ($reqVars as $k => $v) {
+						if (!$v) continue;
 
-						if(!isset($getVars[$k]) ||
+						if (!isset($getVars[$k]) ||
 							($caseInsensitiveMatching && strcasecmp($v, $getVars[$k]) !== 0) ||
 							(!$caseInsensitiveMatching && strcmp($v, $getVars[$k]) !== 0)
 						) {
@@ -94,7 +94,7 @@ class RedirectedURLHandler extends Extension {
 					}
 				}
 
-				if($allVarsMatch) {
+				if ($allVarsMatch) {
 					$matched = $potential;
 					break;
 				}
@@ -102,7 +102,7 @@ class RedirectedURLHandler extends Extension {
 		}
 
 		// If there's a match, direct!
-		if($matched) {
+		if ($matched) {
 			$response = new SS_HTTPResponse();
 			$dest = $matched->To;
 			$response->redirect(Director::absoluteURL($dest), 301);
@@ -111,7 +111,7 @@ class RedirectedURLHandler extends Extension {
 		}
 
 		// Otherwise check for default MOSS-fixing.
-		if(preg_match('/pages\/default.aspx$/i', $base)) {
+		if (preg_match('/pages\/default.aspx$/i', $base)) {
 			$newBase = preg_replace('/pages\/default.aspx$/i', '', $base);
 
 			$response = new SS_HTTPResponse;

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -81,7 +81,7 @@ class RedirectedURLHandler extends Extension {
 					foreach($reqVars as $k => $v) {
 						if(!$v) continue;
 
-						if(!isset($getVars[$k]) || $v != $getVars[$k]) {
+						if(!isset($getVars[$k]) || strcasecmp($v, $getVars[$k]) !== 0) {
 							$allVarsMatch = false;
 							break;
 						}

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -57,7 +57,7 @@ class RedirectedURLHandler extends Extension {
 	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError404($request) {
-		$caseInsensitiveMatching = $this->config()->get('case_insensitive_matching');
+		$caseInsensitiveMatching = Config::inst()->get(get_class($this), 'case_insensitive_matching');
 		$base = $request->getURL();
 		$getVars = $request->getVars();
 

--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -13,32 +13,12 @@
 class RedirectedURLHandler extends Extension {
 
 	/**
-	 * Converts an array of key value pairs to lowercase
-	 *
-	 * @param array $vars key value pairs
-	 * @return array
-	 */
-	protected function arrayToLowercase($vars) {
-		$result = array();
-
-		foreach($vars as $k => $v) {
-			if(is_array($v)) {
-				$result[strtolower($k)] = $this->arrayToLowercase($v);
-			} else {
-			    $result[strtolower($k)] = strtolower($v);
-            }
-		}
-
-		return $result;
-	}
-
-	/**
 	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError404($request) {
-		$base = strtolower($request->getURL());
+		$base = $request->getURL();
 
-		$getVars = $this->arrayToLowercase($request->getVars());
+		$getVars = $request->getVars();
 		unset($getVars['url']);
 
 		// Find all the RedirectedURL objects where the base URL matches.
@@ -58,8 +38,8 @@ class RedirectedURLHandler extends Extension {
 			$basepart = Convert::raw2sql($basestr . '/*');
 			$basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring ASC');
 			foreach ($basepots as $basepot){
-                // If the To URL ends in a wildcard /*, append the remaining request URL elements
-				if (substr($basepot->To, -2) === '/*'){					
+				// If the To URL ends in a wildcard /*, append the remaining request URL elements
+				if (substr($basepot->To, -2) === '/*'){
 					$basepot->To = substr($basepot->To, 0, -2) . substr($base, strlen($basestr));
 				}
 				$listPotentials->push($basepot);

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -6,7 +6,7 @@
  */
 class RedirectedURLHandlerTest extends FunctionalTest {
 
-	protected static $fixture_file = 'silverstripe-redirectedurls/tests/RedirectedURLHandlerTest.yml';
+	protected static $fixture_file = 'redirectedurls/tests/RedirectedURLHandlerTest.yml';
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -6,15 +6,16 @@
  */
 class RedirectedURLHandlerTest extends FunctionalTest {
 
-	protected static $fixture_file = 'redirectedurls/tests/RedirectedURLHandlerTest.yml';
+	protected static $fixture_file = 'silverstripe-redirectedurls/tests/RedirectedURLHandlerTest.yml';
 
 	public function setUp() {
 		parent::setUp();
 		
 		$this->autoFollowRedirection = false;
+		Config::inst()->update('RedirectedURLHandler', 'case_insensitive_matching', false);
 	}
 
-	public function testHanldeRootRedirectWithExtension() {
+	public function testHandleRootRedirectWithExtension() {
 		$redirect = $this->objFromFixture('RedirectedURL', 'redirect-root-extension');
 
 		$response = $this->get($redirect->FromBase);
@@ -63,6 +64,19 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	public function testHandleURLRedirectionWithMixedCaseQuery() {
 		$response = $this->get('query-test-with-mixed-case-query-string?Foo=bar');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-query');
+
+		$this->assertEquals(301, $response->getStatusCode());
+		$this->assertEquals(
+			Director::absoluteURL($expected->To),
+			$response->getHeader('Location')
+		);
+	}
+
+	public function testHandleURLRedirectionWithMixedCaseQueryAndCaseInsensitiveMatching() {
+		Config::inst()->update('RedirectedURLHandler', 'case_insensitive_matching', true);
+
+		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-query');
+		$response = $this->get('query-test-with-mixed-case-query-string?foo=bar');
 
 		$this->assertEquals(301, $response->getStatusCode());
 		$this->assertEquals(

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -50,7 +50,7 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	}
 
 	public function testHandleMixedCaseURLRedirection() {
-		$response = $this->get('Query-test');
+		$response = $this->get('Query-test-with-mixed-case-url');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-url');
 
 		$this->assertEquals(301, $response->getStatusCode());
@@ -61,7 +61,7 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	}
 
 	public function testHandleURLRedirectionWithMixedCaseQuery() {
-		$response = $this->get('query-test-with-query-string?Foo=bar');
+		$response = $this->get('query-test-with-mixed-case-query-string?Foo=bar');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-query');
 
 		$this->assertEquals(301, $response->getStatusCode());

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -62,6 +62,7 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	}
 
 	public function testHandleURLRedirectionWithMixedCaseQuery() {
+		Config::inst()->update('RedirectedURLHandler', 'case_insensitive_matching', false);
 		$response = $this->get('query-test-with-mixed-case-query-string?Foo=bar');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-query');
 

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -41,7 +41,18 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	public function testHandleURLRedirectionWithQueryString() {
 		$response = $this->get('query-test-with-query-string?foo=bar');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-query');
-		
+
+		$this->assertEquals(301, $response->getStatusCode());
+		$this->assertEquals(
+			Director::absoluteURL($expected->To),
+			$response->getHeader('Location')
+		);
+	}
+
+	public function testHandleURLRedirectionWithMixedCaseQueryString() {
+		$response = $this->get('query-test-with-query-string?Foo=bar');
+		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-query');
+
 		$this->assertEquals(301, $response->getStatusCode());
 		$this->assertEquals(
 			Director::absoluteURL($expected->To),

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -39,7 +39,7 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	}
 
 	public function testHandleURLRedirectionWithQueryString() {
-		$response = $this->get('uery-test-with-query-string?foo=bar');
+		$response = $this->get('query-test-with-query-string?foo=bar');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-query');
 
 		$this->assertEquals(301, $response->getStatusCode());

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -59,18 +59,4 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 			$response->getHeader('Location')
 		);
 	}
-
-	public function testArrayToLowercase() {
-		$array = array('Foo' => 'bar', 'baz' => 'QUX');
-		
-		$cont = new RedirectedURLHandler();
-
-		$arrayToLowercaseMethod = new ReflectionMethod('RedirectedURLHandler', 'arrayToLowercase');
-		$arrayToLowercaseMethod->setAccessible(true);
-		
-		$this->assertEquals(
-			array('foo'=> 'bar', 'baz' => 'qux'),
-			$arrayToLowercaseMethod->invoke($cont, $array)
-		);
-	}
 }

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -39,7 +39,7 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 	}
 
 	public function testHandleURLRedirectionWithQueryString() {
-		$response = $this->get('query-test-with-query-string?foo=bar');
+		$response = $this->get('uery-test-with-query-string?foo=bar');
 		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-query');
 
 		$this->assertEquals(301, $response->getStatusCode());
@@ -49,9 +49,20 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 		);
 	}
 
-	public function testHandleURLRedirectionWithMixedCaseQueryString() {
+	public function testHandleMixedCaseURLRedirection() {
+		$response = $this->get('Query-test');
+		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-url');
+
+		$this->assertEquals(301, $response->getStatusCode());
+		$this->assertEquals(
+			Director::absoluteURL($expected->To),
+			$response->getHeader('Location')
+		);
+	}
+
+	public function testHandleURLRedirectionWithMixedCaseQuery() {
 		$response = $this->get('query-test-with-query-string?Foo=bar');
-		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-query');
+		$expected = $this->objFromFixture('RedirectedURL', 'redirect-with-mixed-case-query');
 
 		$this->assertEquals(301, $response->getStatusCode());
 		$this->assertEquals(

--- a/tests/RedirectedURLHandlerTest.yml
+++ b/tests/RedirectedURLHandlerTest.yml
@@ -7,10 +7,10 @@ RedirectedURL:
     FromQueryString: foo=bar
     To: /query-test-foo
   redirect-with-mixed-case-url:
-    FromBase: /Query-test
+    FromBase: /Query-test-with-mixed-case-url
     To: /query-test-foo
   redirect-with-mixed-case-query:
-    FromBase: /query-test-with-query-string
+    FromBase: /query-test-with-mixed-case-query-string
     FromQueryString: Foo=bar
     To: /query-test-foo
   redirect-with-longer-query:

--- a/tests/RedirectedURLHandlerTest.yml
+++ b/tests/RedirectedURLHandlerTest.yml
@@ -6,6 +6,13 @@ RedirectedURL:
     FromBase: /query-test-with-query-string
     FromQueryString: foo=bar
     To: /query-test-foo
+  redirect-with-mixed-case-url:
+    FromBase: /Query-test
+    To: /query-test-foo
+  redirect-with-mixed-case-query:
+    FromBase: /query-test-with-query-string
+    FromQueryString: Foo=bar
+    To: /query-test-foo
   redirect-with-longer-query:
     FromBase: /query-test-with-query-string
     FromQueryString: "foo=bar&baz=qux"


### PR DESCRIPTION
This pull request:
- includes the changes in https://github.com/silverstripe/silverstripe-redirectedurls/issues/43
- removes the forced lower case conversion in the URL handler
- adds unit tests for these changes