### PR TITLE
Match on Redirects that have a QueryStrings before those that don't

### DIFF
--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -60,7 +60,7 @@ class RedirectedURLHandler extends Extension
         // Assumes the base url has no trailing slash.
         $SQL_base = Convert::raw2sql(rtrim($base, '/'));
 
-        $potentials = RedirectedURL::get()->filter(array('FromBase' => '/' . $SQL_base))->sort('FromQuerystring ASC');
+        $potentials = RedirectedURL::get()->filter(array('FromBase' => '/' . $SQL_base))->sort('FromQuerystring DESC');
         $listPotentials = new ArrayList;
         foreach ($potentials as $potential) {
             $listPotentials->push($potential);
@@ -71,7 +71,7 @@ class RedirectedURLHandler extends Extension
         for ($pos = count($baseparts) - 1; $pos >= 0; $pos--) {
             $basestr = implode('/', array_slice($baseparts, 0, $pos));
             $basepart = Convert::raw2sql($basestr . '/*');
-            $basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring ASC');
+            $basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring DESC');
             foreach ($basepots as $basepot) {
                 // If the To URL ends in a wildcard /*, append the remaining request URL elements
                 if (substr($basepot->To, -2) === '/*') {


### PR DESCRIPTION
If there are 2 Redirects and one has a query string and the other doesn't then try and match the one with the query string first as it's more explicit