### PR TITLE
Added internal page redirect and redirect code dropdown

### DIFF
--- a/_config/redirectedurls.yml
+++ b/_config/redirectedurls.yml
@@ -13,3 +13,5 @@ SilverStripe\CMS\Controllers\ModelAsController:
 SilverStripe\ORM\DatabaseAdmin:
   classname_value_remapping:
     RedirectedURL: 'SilverStripe\RedirectedURLs\Model\RedirectedURL'
+SilverStripe\RedirectedURLs\Model\RedirectedURL:
+  defaultRedirectCode: 301

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "silverstripe/framework": "^4",
         "silverstripe/cms": "^4"
+		"unclecheese/display-logic": "~2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "silverstripe/framework": "^4",
-        "silverstripe/cms": "^4"
+        "silverstripe/cms": "^4",
 		"unclecheese/display-logic": "~2"
     },
     "require-dev": {

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -74,7 +74,7 @@ class RedirectedURLHandler extends Extension
             $basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring ASC');
             foreach ($basepots as $basepot) {
                 // If the To URL ends in a wildcard /*, append the remaining request URL elements
-                if (substr($basepot->To, -2) === '/*') {
+                if ($basepot->RedirectionType === 'External' && substr($basepot->To, -2) === '/*') {
                     $basepot->To = substr($basepot->To, 0, -2) . substr($base, strlen($basestr));
                 }
                 $listPotentials->push($basepot);
@@ -115,7 +115,7 @@ class RedirectedURLHandler extends Extension
         // If there's a match, direct!
         if ($matched) {
             $response = new HTTPResponse();
-            $dest = $matched->To;
+            $dest = $matched->Link();
             $response->redirect(Director::absoluteURL($dest), 301);
 
             throw new HTTPResponse_Exception($response);

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -13,6 +13,7 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\RedirectedURLs\Model\RedirectedURL;
+use SilverStripe\Core\Config\Config;
 
 /**
  * Handles the redirection of any url from a controller.
@@ -44,6 +45,23 @@ class RedirectedURLHandler extends Extension
         }
 
         return $result;
+    }
+
+    protected function getRedirectCode($redirectedURL = false)
+    {
+        if ($redirectedURL instanceof RedirectedURL) {
+            if (isset($redirectedURL->RedirectCode) && intval($redirectedURL->RedirectCode) > 0) {
+                return intval($redirectedURL->RedirectCode);
+            }
+        }
+
+        $redirectCode = 301;
+        $defaultRedirectCode = intval(Config::inst()->get(RedirectedURL::class, 'defaultRedirectCode'));
+        if ($defaultRedirectCode > 0) {
+            $redirectCode = $defaultRedirectCode;
+        }
+
+        return $redirectCode;
     }
 
     /**
@@ -116,7 +134,7 @@ class RedirectedURLHandler extends Extension
         if ($matched) {
             $response = new HTTPResponse();
             $dest = $matched->Link();
-            $response->redirect(Director::absoluteURL($dest), 301);
+            $response->redirect(Director::absoluteURL($dest), $this->getRedirectCode($matched));
 
             throw new HTTPResponse_Exception($response);
         }
@@ -126,7 +144,7 @@ class RedirectedURLHandler extends Extension
             $newBase = preg_replace('/pages\/default.aspx$/i', '', $base);
 
             $response = new HTTPResponse;
-            $response->redirect(Director::absoluteURL($newBase), 301);
+            $response->redirect(Director::absoluteURL($newBase), $this->getRedirectCode());
 
             throw new HTTPResponse_Exception($response);
         }

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -153,7 +153,6 @@ class RedirectedURL extends DataObject implements PermissionProvider
         $toField->setDescription(_t(__CLASS__.'.FIELD_DESCRIPTION_TO', 'e.g. /about?something=5'));
         $toField->displayIf('RedirectionType')->isEqualTo('External');
 
-        $linkToField->setDescription(_t(__CLASS__.'.FIELD_DESCRIPTION_LINKTO', 'select a desired page from the dropdown menu'));
         $linkToWrapperField->displayIf('RedirectionType')->isEqualTo('Internal');
 
         return $fields;

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -12,6 +12,8 @@ use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\CMS\Model\RedirectorPage;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\DropdownField;
 
 /**
  * Specifies one URL redirection
@@ -46,6 +48,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
         'FromQuerystring' => 'Varchar(255)',
         'To' => 'Varchar(255)',
         'RedirectionType' => 'Enum("Internal,External", "Internal")',
+        'RedirectCode' => 'Int',
     );
 
     /**
@@ -78,7 +81,9 @@ class RedirectedURL extends DataObject implements PermissionProvider
         'FromBase' => 'From URL base',
         'FromQuerystring' => 'From URL query parameters',
         'To' => 'To URL',
+        'LinkTo.Title' => 'Link To',
         'RedirectionType' => 'Redirection type',
+        'RedirectCode' => 'Redirect code',
     );
 
     /**
@@ -98,6 +103,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
         $fields->removeByName([
             'FromBase',
             'FromQuerystring',
+            'RedirectCode',
             'To',
             'RedirectionType',
             'LinkToID',
@@ -112,6 +118,11 @@ class RedirectedURL extends DataObject implements PermissionProvider
                 $fromQueryStringField = TextField::create(
                     'FromQuerystring',
                     _t(__CLASS__.'.FIELD_TITLE_FROMQUERYSTRING', 'From querystring')
+                ),
+                $redirectCodeField = DropdownField::create(
+                    'RedirectCode',
+                    _t(__CLASS__.'.FIELD_TITLE_REDIRECTCODE', 'Redirect code'),
+                    $this->getCodes()
                 ),
                 $redirectionTypeField = OptionsetField::create(
                     'RedirectionType',
@@ -145,6 +156,40 @@ class RedirectedURL extends DataObject implements PermissionProvider
         $linkToWrapperField->displayIf('RedirectionType')->isEqualTo('Internal');
 
         return $fields;
+    }
+
+    /**
+     * @return int
+     */
+    public function populateDefaults()
+    {
+        $this->RedirectCode = $this->getRedirectCodeDefault();
+    }
+
+    /**
+     * @return int
+     */
+    private function getRedirectCodeDefault()
+    {
+        $redirectCodeValue = 301;
+
+        $defaultRedirectCode = intval(Config::inst()->get(RedirectedURL::class, 'defaultRedirectCode'));
+        if ($defaultRedirectCode > 0) {
+            $redirectCodeValue = $defaultRedirectCode;
+        }
+
+        return $redirectCodeValue;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getCodes()
+    {
+        return [
+            301 =. _t(__CLASS__.'.CODE_301', '301 - Permanent'),
+            302 =. _t(__CLASS__.'.CODE_302', '302 - Temporary'),
+        ];
     }
 
     /**

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -110,7 +110,8 @@ class RedirectedURL extends DataObject implements PermissionProvider
         ]);
 
         $fields->addFieldsToTab(
-            'Root.Main', [
+            'Root.Main',
+            [
                 $fromBaseField = TextField::create(
                     'FromBase',
                     _t(__CLASS__.'.FIELD_TITLE_FROMBASE', 'From base')

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -6,6 +6,12 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
+use SilverStripe\Forms\TextField;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\OptionsetField;
+use SilverStripe\Forms\TreeDropdownField;
+use SilverStripe\CMS\Model\RedirectorPage;
+use UncleCheese\DisplayLogic\Forms\Wrapper;
 
 /**
  * Specifies one URL redirection
@@ -39,6 +45,15 @@ class RedirectedURL extends DataObject implements PermissionProvider
         'FromBase' => 'Varchar(255)',
         'FromQuerystring' => 'Varchar(255)',
         'To' => 'Varchar(255)',
+        'RedirectionType' => 'Enum("Internal,External", "Internal")',
+    );
+
+    /**
+     * @var array
+     * @config
+     */
+    private static $has_one = array(
+        'LinkTo' => SiteTree::class,
     );
 
     /**
@@ -63,6 +78,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
         'FromBase' => 'From URL base',
         'FromQuerystring' => 'From URL query parameters',
         'To' => 'To URL',
+        'RedirectionType' => 'Redirection type',
     );
 
     /**
@@ -79,14 +95,54 @@ class RedirectedURL extends DataObject implements PermissionProvider
     {
         $fields = parent::getCMSFields();
 
-        $fromBaseField = $fields->fieldByName('Root.Main.FromBase');
-        $fromBaseField->setDescription('e.g. /about-us.html');
+        $fields->removeByName([
+            'FromBase',
+            'FromQuerystring',
+            'To',
+            'RedirectionType',
+            'LinkToID',
+        ]);
 
-        $fromQueryStringField = $fields->fieldByName('Root.Main.FromQuerystring');
-        $fromQueryStringField->setDescription('e.g. page=1&num=5');
+        $fields->addFieldsToTab(
+            'Root.Main', [
+                $fromBaseField = TextField::create(
+                    'FromBase',
+                    _t(__CLASS__.'.FIELD_TITLE_FROMBASE', 'From base')
+                ),
+                $fromQueryStringField = TextField::create(
+                    'FromQuerystring',
+                    _t(__CLASS__.'.FIELD_TITLE_FROMQUERYSTRING', 'From querystring')
+                ),
+                $redirectionTypeField = OptionsetField::create(
+                    'RedirectionType',
+                    _t(__CLASS__.'.FIELD_TITLE_REDIRECTIONTYPE', 'Redirect to'),
+                    [
+                        'Internal' => _t(__CLASS__.'.FIELD_REDIRECTIONTYPE_OPTION_INTERNAL', 'A page on your website'),
+                        'External' => _t(__CLASS__.'.FIELD_REDIRECTIONTYPE_OPTION_EXTERNAL', 'Another website'),
+                    ],
+                    'Internal'
+                ),
+                $toField = TextField::create(
+                    'To',
+                    _t(__CLASS__.'.FIELD_TITLE_TO', 'To')
+                ),
+                $linkToWrapperField = Wrapper::create($linkToField = TreeDropdownField::create(
+                    'LinkToID',
+                    _t(__CLASS__.'.FIELD_TITLE_LINKTOID', 'Page on your website'),
+                    SiteTree::class
+                )),
+            ]
+        );
 
-        $toField = $fields->fieldByName('Root.Main.To');
-        $toField->setDescription('e.g. /about?something=5');
+        $fromBaseField->setDescription(_t(__CLASS__.'.FIELD_DESCRIPTION_FROMBASE', 'e.g. /about-us.html'));
+        
+        $fromQueryStringField->setDescription(_t(__CLASS__.'.FIELD_DESCRIPTION_FROMQUERYSTRING', 'e.g. page=1&num=5'));
+        
+        $toField->setDescription(_t(__CLASS__.'.FIELD_DESCRIPTION_TO', 'e.g. /about?something=5'));
+        $toField->displayIf('RedirectionType')->isEqualTo('External');
+
+        $linkToField->setDescription(_t(__CLASS__.'.FIELD_DESCRIPTION_LINKTO', 'select a desired page from the dropdown menu'));
+        $linkToWrapperField->displayIf('RedirectionType')->isEqualTo('Internal');
 
         return $fields;
     }
@@ -236,5 +292,39 @@ class RedirectedURL extends DataObject implements PermissionProvider
     public function canDelete($member = null)
     {
         return Permission::checkMember($member, 'REDIRECTEDURLS_DELETE');
+    }
+
+    /**
+     * @return string
+     */
+    public function Link()
+    {
+        // Check external redirect
+        if ($this->RedirectionType === 'External') {
+            return $this->To ?: null;
+        }
+
+        // Check internal redirect
+        /** @var SiteTree $linkTo */
+        $linkTo = $this->LinkToID ? SiteTree::get()->byID($this->LinkToID) : null;
+        if (empty($linkTo)) {
+            return null;
+        }
+
+        // We shouldn't point to ourselves - that would create an infinite loop!  Return null since we have a
+        // bad configuration
+        if (intval($this->ID) === intval($linkTo->ID)) {
+            return null;
+        }
+
+        // If we're linking to another redirectorpage then just return the URLSegment, to prevent a cycle of redirector
+        // pages from causing an infinite loop.  Instead, they will cause a 30x redirection loop in the browser, but
+        // this can be handled sufficiently gracefully by the browser.
+        if ($linkTo instanceof RedirectorPage) {
+            return $linkTo->regularLink();
+        }
+
+        // For all other pages, just return the link of the page.
+        return $linkTo->RelativeLink();
     }
 }

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -138,7 +138,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
                     'To',
                     _t(__CLASS__.'.FIELD_TITLE_TO', 'To')
                 ),
-                $linkToWrapperField = Wrapper::create($linkToField = TreeDropdownField::create(
+                $linkToWrapperField = Wrapper::create(TreeDropdownField::create(
                     'LinkToID',
                     _t(__CLASS__.'.FIELD_TITLE_LINKTOID', 'Page on your website'),
                     SiteTree::class

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -187,8 +187,8 @@ class RedirectedURL extends DataObject implements PermissionProvider
     protected function getCodes()
     {
         return [
-            301 =. _t(__CLASS__.'.CODE_301', '301 - Permanent'),
-            302 =. _t(__CLASS__.'.CODE_302', '302 - Temporary'),
+            301 => _t(__CLASS__.'.CODE_301', '301 - Permanent'),
+            302 => _t(__CLASS__.'.CODE_302', '302 - Temporary'),
         ];
     }
 


### PR DESCRIPTION
Added a SiteTree dropdown field so that you can redirect directly to internal pages, so that if the menu structure changes the redirect still works.

Added a redirect code dropdown so that you can select which redirect code you want to use, because 301 is volatile.
The default is still 301, so that it doesn't break anything.