### PR TITLE
Internal redirect and code

### DIFF
--- a/_config/redirectedurls.yml
+++ b/_config/redirectedurls.yml
@@ -13,3 +13,5 @@ SilverStripe\CMS\Controllers\ModelAsController:
 SilverStripe\ORM\DatabaseAdmin:
   classname_value_remapping:
     RedirectedURL: 'SilverStripe\RedirectedURLs\Model\RedirectedURL'
+SilverStripe\RedirectedURLs\Model\RedirectedURL:
+  default_redirect_code: 301

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "silverstripe/framework": "^4",
-        "silverstripe/cms": "^4"
+        "silverstripe/cms": "^4",
+		"unclecheese/display-logic": "~2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5",

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -74,7 +74,7 @@ class RedirectedURLHandler extends Extension
             $basepots = RedirectedURL::get()->filter(array('FromBase' => '/' . $basepart))->sort('FromQuerystring DESC');
             foreach ($basepots as $basepot) {
                 // If the To URL ends in a wildcard /*, append the remaining request URL elements
-                if (substr($basepot->To, -2) === '/*') {
+                if ($basepot->RedirectionType === 'External' && substr($basepot->To, -2) === '/*') {
                     $basepot->To = substr($basepot->To, 0, -2) . substr($base, strlen($basestr));
                 }
                 $listPotentials->push($basepot);
@@ -115,7 +115,7 @@ class RedirectedURLHandler extends Extension
         // If there's a match, direct!
         if ($matched) {
             $response = new HTTPResponse();
-            $dest = $matched->To;
+            $dest = $matched->Link();
             $response->redirect(Director::absoluteURL($dest), 301);
 
             throw new HTTPResponse_Exception($response);

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -13,6 +13,7 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\RedirectedURLs\Model\RedirectedURL;
+use SilverStripe\Core\Config\Config;
 
 /**
  * Handles the redirection of any url from a controller.
@@ -44,6 +45,23 @@ class RedirectedURLHandler extends Extension
         }
 
         return $result;
+    }
+
+    protected function getRedirectCode($redirectedURL = false)
+    {
+        if ($redirectedURL instanceof RedirectedURL) {
+            if (isset($redirectedURL->RedirectCode) && intval($redirectedURL->RedirectCode) > 0) {
+                return intval($redirectedURL->RedirectCode);
+            }
+        }
+
+        $redirectCode = 301;
+        $defaultRedirectCode = intval(Config::inst()->get(RedirectedURL::class, 'default_redirect_code'));
+        if ($defaultRedirectCode > 0) {
+            $redirectCode = $defaultRedirectCode;
+        }
+
+        return $redirectCode;
     }
 
     /**
@@ -116,7 +134,7 @@ class RedirectedURLHandler extends Extension
         if ($matched) {
             $response = new HTTPResponse();
             $dest = $matched->Link();
-            $response->redirect(Director::absoluteURL($dest), 301);
+            $response->redirect(Director::absoluteURL($dest), $this->getRedirectCode($matched));
 
             throw new HTTPResponse_Exception($response);
         }
@@ -126,7 +144,7 @@ class RedirectedURLHandler extends Extension
             $newBase = preg_replace('/pages\/default.aspx$/i', '', $base);
 
             $response = new HTTPResponse;
-            $response->redirect(Director::absoluteURL($newBase), 301);
+            $response->redirect(Director::absoluteURL($newBase), $this->getRedirectCode());
 
             throw new HTTPResponse_Exception($response);
         }


### PR DESCRIPTION
Rebase to newest master, resolved all the conflicts.

Added a SiteTree dropdown field so that you can redirect directly to internal pages, so that if the menu structure changes the redirect still works.

Added a redirect code dropdown so that you can select which redirect code you want to use, because 301 is volatile.
The default is still 301, so that it doesn't break anything.