### PR TITLE
FEAT: Allow redirectedurls to apply to assets

### DIFF
--- a/_config/redirectedurls.yml
+++ b/_config/redirectedurls.yml
@@ -1,17 +1,29 @@
 ---
-name: redirectedurls
+Name: redirectedurls
 ---
 SilverStripe\Control\RequestHandler:
   extensions:
     - SilverStripe\RedirectedURLs\Extension\RedirectedURLHandler
+
 SilverStripe\CMS\Controllers\ContentController:
   extensions:
     - SilverStripe\RedirectedURLs\Extension\RedirectedURLHandler
+
 SilverStripe\CMS\Controllers\ModelAsController:
   extensions:
     - SilverStripe\RedirectedURLs\Extension\RedirectedURLHandler
+
 SilverStripe\ORM\DatabaseAdmin:
   classname_value_remapping:
     RedirectedURL: 'SilverStripe\RedirectedURLs\Model\RedirectedURL'
+
 SilverStripe\RedirectedURLs\Model\RedirectedURL:
   default_redirect_code: 301
+---
+Name: redirectedurls-assets
+Only:
+  moduleexists: 'silverstripe/assets'
+---
+SilverStripe\Assets\Flysystem\FlysystemAssetStore:
+  extensions:
+    - SilverStripe\RedirectedURLs\Extension\AssetStoreURLHandler

--- a/src/Extension/AssetStoreURLHandler.php
+++ b/src/Extension/AssetStoreURLHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\RedirectedURLs\Extension;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\RedirectedURLs\Model\RedirectedURL;
+use SilverStripe\RedirectedURLs\Service\RedirectedURLService;
+
+/**
+ * Class AssetStoreURLHandler
+ * @package SilverStripe\RedirectedURLs\Extension
+ *
+ * This extension applies to FlysystemAssetStore, and ensures that an appropriate redirect response is returned when an
+ * asset isn't found and the path matches a {@link RedirectedURL} object.
+ */
+class AssetStoreURLHandler extends Extension
+{
+    /**
+     * @var array An array of HTTP status codes that should be acted upon if they are returned by the AssetStore.
+     * @config
+     */
+    private static $act_upon = [
+        404
+    ];
+
+    public function updateResponse(HTTPResponse &$response, string $asset, array $context = [])
+    {
+        // Only change the response if the response provided by FlysystemAssetStore matches one we should act on
+        if (in_array($response->getStatusCode(), $this->owner->config()->act_upon)) {
+            // Get the current request, then attempt to find a RedirectedURL object that matches
+            if (Controller::has_curr()) {
+                $controller = Controller::curr();
+                $request = $controller->getRequest();
+
+                /** @var RedirectedURLService $service */
+                $service = Injector::inst()->get(RedirectedURLService::class);
+                $match = $service->findBestRedirectedURLMatch($request);
+
+                if ($match) {
+                    // We have a matching RedirectedURL, so replace the base HTTPResponse provided by
+                    // FlysystemAssetStore with our redirect response
+                    $response = $service->getResponse($match);
+                }
+            }
+        }
+    }
+}

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -27,45 +27,6 @@ use SilverStripe\RedirectedURLs\Service\RedirectedURLService;
  */
 class RedirectedURLHandler extends Extension
 {
-
-    /**
-     * Converts an array of key value pairs to lowercase
-     *
-     * @param array $vars key value pairs
-     * @return array
-     */
-    protected function arrayToLowercase($vars)
-    {
-        $result = array();
-
-        foreach ($vars as $k => $v) {
-            if (is_array($v)) {
-                $result[strtolower($k)] = $this->arrayToLowercase($v);
-            } else {
-                $result[strtolower($k)] = strtolower($v);
-            }
-        }
-
-        return $result;
-    }
-
-    protected function getRedirectCode($redirectedURL = false)
-    {
-        if ($redirectedURL instanceof RedirectedURL) {
-            if (isset($redirectedURL->RedirectCode) && intval($redirectedURL->RedirectCode) > 0) {
-                return intval($redirectedURL->RedirectCode);
-            }
-        }
-
-        $redirectCode = 301;
-        $defaultRedirectCode = intval(Config::inst()->get(RedirectedURL::class, 'default_redirect_code'));
-        if ($defaultRedirectCode > 0) {
-            $redirectCode = $defaultRedirectCode;
-        }
-
-        return $redirectCode;
-    }
-
     /**
      * @throws HTTPResponse_Exception
      * @param HTTPRequest $request

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -11,9 +11,11 @@ use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\RedirectedURLs\Model\RedirectedURL;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\RedirectedURLs\Service\RedirectedURLService;
 
 /**
  * Handles the redirection of any url from a controller.
@@ -68,85 +70,15 @@ class RedirectedURLHandler extends Extension
      * @throws HTTPResponse_Exception
      * @param HTTPRequest $request
      */
-    public function onBeforeHTTPError404($request)
+    public function onBeforeHTTPError404(HTTPRequest $request)
     {
-        $base = strtolower($request->getURL());
+        /** @var RedirectedURLService $service */
+        $service = Injector::inst()->get(RedirectedURLService::class);
 
-        $getVars = $this->arrayToLowercase($request->getVars());
+        $match = $service->findBestRedirectedURLMatch($request);
 
-        // Find all the RedirectedURL objects where the base URL matches.
-        // Assumes the base url has no trailing slash.
-        $SQL_base = Convert::raw2sql(rtrim($base, '/'));
-
-        $potentials = RedirectedURL::get()->filter(['FromBase' => '/' . $SQL_base])->sort('FromQuerystring DESC');
-        $listPotentials = new ArrayList();
-        foreach ($potentials as $potential) {
-            $listPotentials->push($potential);
-        }
-
-        // Find any matching FromBase elements terminating in a wildcard /*
-        $baseparts = explode('/', $base);
-        for ($pos = count($baseparts) - 1; $pos >= 0; $pos--) {
-            $basestr = implode('/', array_slice($baseparts, 0, $pos));
-            $basepart = Convert::raw2sql($basestr . '/*');
-            $basepots = RedirectedURL::get()->filter(['FromBase' => '/' . $basepart])->sort('FromQuerystring DESC');
-            foreach ($basepots as $basepot) {
-                // If the To URL ends in a wildcard /*, append the remaining request URL elements
-                if ($basepot->RedirectionType === 'External' && substr($basepot->To, -2) === '/*') {
-                    $basepot->To = substr($basepot->To, 0, -2) . substr($base, strlen($basestr));
-                }
-                $listPotentials->push($basepot);
-            }
-        }
-
-        $matched = null;
-
-        // Then check the get vars, ignoring any additional get vars that
-        // this URL may have
-        if ($listPotentials) {
-            foreach ($listPotentials as $potential) {
-                $allVarsMatch = true;
-
-                if ($potential->FromQuerystring) {
-                    $reqVars = array();
-                    parse_str($potential->FromQuerystring, $reqVars);
-
-                    foreach ($reqVars as $k => $v) {
-                        if (!$v) {
-                            continue;
-                        }
-
-                        if (!isset($getVars[$k]) || $v != $getVars[$k]) {
-                            $allVarsMatch = false;
-                            break;
-                        }
-                    }
-                }
-
-                if ($allVarsMatch) {
-                    $matched = $potential;
-                    break;
-                }
-            }
-        }
-
-        // If there's a match, direct!
-        if ($matched) {
-            $response = new HTTPResponse();
-            $dest = $matched->Link();
-            $response->redirect(Director::absoluteURL($dest), $this->getRedirectCode($matched));
-
-            throw new HTTPResponse_Exception($response);
-        }
-
-        // Otherwise check for default MOSS-fixing.
-        if (preg_match('/pages\/default.aspx$/i', $base)) {
-            $newBase = preg_replace('/pages\/default.aspx$/i', '', $base);
-
-            $response = new HTTPResponse();
-            $response->redirect(Director::absoluteURL($newBase), $this->getRedirectCode());
-
-            throw new HTTPResponse_Exception($response);
+        if ($match) {
+            throw new HTTPResponse_Exception($service->getResponse($match));
         }
     }
 }

--- a/src/Service/RedirectedURLService.php
+++ b/src/Service/RedirectedURLService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace SilverStripe\RedirectedURLs\Service;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Convert;
+use SilverStripe\Core\Extensible;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\RedirectedURLs\Model\RedirectedURL;
+
+class RedirectedURLService
+{
+    use Extensible, Configurable;
+
+    /**
+     * @param HTTPRequest $request
+     * @return RedirectedURL|null
+     */
+    public function findBestRedirectedURLMatch(HTTPRequest $request): ?RedirectedURL
+    {
+        $base = strtolower($request->getURL());
+        $getVars = $this->arrayToLowercase($request->getVars());
+
+        // Find all the RedirectedURL objects where the base URL matches.
+        // Assumes the base url has no trailing slash.
+        $SQL_base = Convert::raw2sql(rtrim($base, '/'));
+
+        $potentials = RedirectedURL::get()->filter(['FromBase' => '/' . $SQL_base])->sort('FromQuerystring DESC');
+        $listPotentials = new ArrayList();
+        foreach ($potentials as $potential) {
+            $listPotentials->push($potential);
+        }
+
+        // Find any matching FromBase elements terminating in a wildcard /*
+        $baseparts = explode('/', $base);
+        for ($pos = count($baseparts) - 1; $pos >= 0; $pos--) {
+            $basestr = implode('/', array_slice($baseparts, 0, $pos));
+            $basepart = Convert::raw2sql($basestr . '/*');
+            $basepots = RedirectedURL::get()->filter(['FromBase' => '/' . $basepart])->sort('FromQuerystring DESC');
+            foreach ($basepots as $basepot) {
+                // If the To URL ends in a wildcard /*, append the remaining request URL elements
+                if ($basepot->RedirectionType === 'External' && substr($basepot->To, -2) === '/*') {
+                    $basepot->To = substr($basepot->To, 0, -2) . substr($base, strlen($basestr));
+                }
+                $listPotentials->push($basepot);
+            }
+        }
+
+        $matched = null;
+
+        // Then check the get vars, ignoring any additional get vars that
+        // this URL may have
+        if ($listPotentials) {
+            foreach ($listPotentials as $potential) {
+                $allVarsMatch = true;
+
+                if ($potential->FromQuerystring) {
+                    $reqVars = array();
+                    parse_str($potential->FromQuerystring, $reqVars);
+
+                    foreach ($reqVars as $k => $v) {
+                        if (!$v) {
+                            continue;
+                        }
+
+                        if (!isset($getVars[$k]) || $v != $getVars[$k]) {
+                            $allVarsMatch = false;
+                            break;
+                        }
+                    }
+                }
+
+                if ($allVarsMatch) {
+                    $matched = $potential;
+                    break;
+                }
+            }
+        }
+
+        // If we found a match, we return it - otherwise we return null to indicate that no match was found
+        return $matched;
+    }
+
+    public function getResponse(RedirectedURL $redirect): HTTPResponse
+    {
+        $response = HTTPResponse::create()
+            ->redirect(Director::absoluteURL($redirect->Link()), $this->getRedirectCode($redirect));
+
+        return $response;
+    }
+
+    /**
+     * Converts an array of key value pairs to lowercase
+     *
+     * @param array $vars key value pairs
+     * @return array
+     */
+    protected function arrayToLowercase($vars)
+    {
+        $result = array();
+
+        foreach ($vars as $k => $v) {
+            if (is_array($v)) {
+                $result[strtolower($k)] = $this->arrayToLowercase($v);
+            } else {
+                $result[strtolower($k)] = strtolower($v);
+            }
+        }
+
+        return $result;
+    }
+
+    public function getRedirectCode($redirectedURL = null)
+    {
+        if ($redirectedURL instanceof RedirectedURL) {
+            if (isset($redirectedURL->RedirectCode) && intval($redirectedURL->RedirectCode) > 0) {
+                return intval($redirectedURL->RedirectCode);
+            }
+        }
+
+        $redirectCode = 301;
+        $defaultRedirectCode = intval(Config::inst()->get(RedirectedURL::class, 'default_redirect_code'));
+        if ($defaultRedirectCode > 0) {
+            $redirectCode = $defaultRedirectCode;
+        }
+
+        return $redirectCode;
+    }
+}

--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -59,19 +59,4 @@ class RedirectedURLHandlerTest extends FunctionalTest
             $response->getHeader('Location')
         );
     }
-
-    public function testArrayToLowercase()
-    {
-        $array = array('Foo' => 'bar', 'baz' => 'QUX');
-
-        $cont = new RedirectedURLHandler();
-
-        $arrayToLowercaseMethod = new ReflectionMethod(RedirectedURLHandler::class, 'arrayToLowercase');
-        $arrayToLowercaseMethod->setAccessible(true);
-
-        $this->assertEquals(
-            array('foo' => 'bar', 'baz' => 'qux'),
-            $arrayToLowercaseMethod->invoke($cont, $array)
-        );
-    }
 }

--- a/tests/RedirectedURLServiceTest.php
+++ b/tests/RedirectedURLServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SilverStripe\RedirectedURLs\Test;
+
+use ReflectionMethod;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\RedirectedURLs\Extension\RedirectedURLHandler;
+use SilverStripe\RedirectedURLs\Service\RedirectedURLService;
+
+class RedirectedURLServiceTest extends FunctionalTest
+{
+    public function testArrayToLowercase()
+    {
+        $array = array('Foo' => 'bar', 'baz' => 'QUX');
+
+        $cont = new RedirectedURLService();
+
+        $arrayToLowercaseMethod = new ReflectionMethod(RedirectedURLService::class, 'arrayToLowercase');
+        $arrayToLowercaseMethod->setAccessible(true);
+
+        $this->assertEquals(
+            array('foo' => 'bar', 'baz' => 'qux'),
+            $arrayToLowercaseMethod->invoke($cont, $array)
+        );
+    }
+}


### PR DESCRIPTION
This only applies if the `silverstripe/assets` module is installed, we don't require it for this module.

Note: Requires silverstripe/silverstripe-assets/pull/391 to be merged prior to merging this. As such we probably shouldn't merge this until that has been merged and a new stable released (so a new stable of this module can be released to coincide with it - although I don't think you can specify 'minimum version of a suggested module', right?)