### PR TITLE
Add support for Silverstripe 5. Update property/return types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /resources/
 /vendor/
+.idea/

--- a/README.md
+++ b/README.md
@@ -19,12 +19,22 @@ admin included.
 The redirection is implemented as a plug-in to the 404 handler, which means that you can't create a
 redirection for a page that already exists on the site.
 
+## Requirements
+
+* PHP `^8.1`
+* Silverstripe CMS `^5`
+
+Legacy:
+
+* Silverstripe CMS `^4`: `^2` tags
+* Silverstripe CMS `^3`: `^1` tags
+
 ## Installation
 
 - Use composer to run the following in the command line:
 
 ```
-  composer require silverstripe/redirectedurls dev-master
+  composer require silverstripe/redirectedurls
 ```
 
 - Then run **dev/build** (http://www.mysite.com/dev/build)

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8",
-        "silverstripe/framework": "^4",
-        "silverstripe/cms": "^4",
-		"unclecheese/display-logic": "~2"
+        "php": "^8.1",
+        "silverstripe/cms": "^5",
+        "unclecheese/display-logic": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^2",
+        "silverstripe/recipe-testing": "^3",
         "squizlabs/php_codesniffer": "^3"
     },
     "autoload": {
@@ -43,7 +42,7 @@
             "images"
         ],
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         },
         "project-files-installed": [
             "behat.yml",

--- a/src/Admin/RedirectedURLAdmin.php
+++ b/src/Admin/RedirectedURLAdmin.php
@@ -31,7 +31,7 @@ class RedirectedURLAdmin extends ModelAdmin
      *
      * @return array Map of model class names to importer instances
      */
-    public function getModelImporters()
+    public function getModelImporters(): array
     {
         $importer = CsvBulkLoader::create(RedirectedURL::class);
         $importer->duplicateChecks = [
@@ -48,10 +48,8 @@ class RedirectedURLAdmin extends ModelAdmin
      *
      * To prevent field name conversion in DataObject::summaryFields() during export
      * e.g. 'FromBase' is output as 'From Base'
-     *
-     * @return array
      */
-    public function getExportFields()
+    public function getExportFields(): array
     {
         $fields = array();
 

--- a/src/Extension/AssetStoreURLHandler.php
+++ b/src/Extension/AssetStoreURLHandler.php
@@ -16,13 +16,12 @@ class AssetStoreURLHandler extends Extension
 {
     /**
      * @var array An array of HTTP status codes that should be acted upon if they are returned by the AssetStore.
-     * @config
      */
     private static array $act_upon = [
         404,
     ];
 
-    public function updateResponse(HTTPResponse &$response, string $asset, array $context = [])
+    public function updateResponse(HTTPResponse &$response, string $asset, array $context = []): void
     {
         // Only change the response if the response provided by FlysystemAssetStore matches one we should act on
         if (!in_array($response->getStatusCode(), $this->owner->config()->act_upon)) {

--- a/src/Extension/RedirectedURLHandler.php
+++ b/src/Extension/RedirectedURLHandler.php
@@ -9,8 +9,6 @@ use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Extension;
 use SilverStripe\RedirectedURLs\Service\RedirectedURLService;
-use SilverStripe\RedirectedURLs\Support\Arr;
-use SilverStripe\RedirectedURLs\Support\StatusCode;
 
 /**
  * Handles the redirection of any url from a controller.
@@ -19,28 +17,10 @@ use SilverStripe\RedirectedURLs\Support\StatusCode;
  */
 class RedirectedURLHandler extends Extension
 {
-
-    /**
-     * Converts an array of key value pairs to lowercase
-     *
-     * @param array $vars key value pairs
-     * @return array
-     */
-    protected function arrayToLowercase($vars)
-    {
-        return Arr::toLowercase((array) $vars);
-    }
-
-    protected function getRedirectCode($redirectedURL = false)
-    {
-        return StatusCode::getRedirectCode($redirectedURL);
-    }
-
     /**
      * @throws HTTPResponse_Exception
-     * @param HTTPRequest $request
      */
-    public function onBeforeHTTPError404(HTTPRequest $request)
+    public function onBeforeHTTPError404(HTTPRequest $request): void
     {
         $service = RedirectedURLService::create();
 

--- a/src/Model/RedirectedURL.php
+++ b/src/Model/RedirectedURL.php
@@ -165,7 +165,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
     {
         parent::onBeforeWrite();
 
-        $this->ensureBaseFromValidity($this->FromBase);
+        $this->ensureFromBaseValidity($this->FromBase);
         $this->ensureFromQuerystringValidity($this->FromQuerystring);
     }
 
@@ -186,7 +186,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
             $querystring = null;
         }
 
-        $this->ensureBaseFromValidity($base);
+        $this->ensureFromBaseValidity($base);
         $this->ensureFromQuerystringValidity($querystring);
 
         return $this;
@@ -323,7 +323,7 @@ class RedirectedURL extends DataObject implements PermissionProvider
         return $redirectCodeValue;
     }
 
-    private function ensureBaseFromValidity(?string $fromBase): void
+    private function ensureFromBaseValidity(?string $fromBase): void
     {
         if (!$fromBase) {
             return;

--- a/src/Service/RedirectedURLService.php
+++ b/src/Service/RedirectedURLService.php
@@ -16,12 +16,10 @@ use SilverStripe\RedirectedURLs\Support\StatusCode;
 
 class RedirectedURLService implements RedirectedURLInterface
 {
-    use Extensible, Configurable, Injectable;
+    use Extensible;
+    use Configurable;
+    use Injectable;
 
-    /**
-     * @param HTTPRequest $request
-     * @return RedirectedURL|null
-     */
     public function findBestRedirectedURLMatch(HTTPRequest $request): ?RedirectedURL
     {
         $base = strtolower($request->getURL());
@@ -32,6 +30,7 @@ class RedirectedURLService implements RedirectedURLInterface
         $SQL_base = Convert::raw2sql(rtrim($base, '/'));
 
         $potentials = RedirectedURL::get()->filter(['FromBase' => '/' . $SQL_base])->sort('FromQuerystring DESC');
+        /** @var ArrayList|RedirectedURL[] $listPotentials */
         $listPotentials = new ArrayList();
 
         foreach ($potentials as $potential) {
@@ -98,7 +97,7 @@ class RedirectedURLService implements RedirectedURLInterface
     public function getResponse(RedirectedURL $redirect): HTTPResponse
     {
         $response = HTTPResponse::create()
-            ->redirect(Director::absoluteURL($redirect->Link()), StatusCode::getRedirectCode($redirect));
+            ->redirect(Director::absoluteURL($redirect->Link() ?? ''), StatusCode::getRedirectCode($redirect));
 
         return $response;
     }

--- a/src/Support/StatusCode.php
+++ b/src/Support/StatusCode.php
@@ -10,8 +10,8 @@ class StatusCode
     public static function getRedirectCode(?RedirectedURL $redirectedURL = null): int
     {
         if ($redirectedURL instanceof RedirectedURL) {
-            if (isset($redirectedURL->RedirectCode) && (int) $redirectedURL->RedirectCode > 0) {
-                return (int) $redirectedURL->RedirectCode;
+            if (isset($redirectedURL->RedirectCode) && $redirectedURL->RedirectCode > 0) {
+                return $redirectedURL->RedirectCode;
             }
         }
 

--- a/tests/Extension/RedirectedURLHandlerTest.php
+++ b/tests/Extension/RedirectedURLHandlerTest.php
@@ -23,19 +23,18 @@ class RedirectedURLHandlerTest extends FunctionalTest
         $response = $this->get('/signups/');
 
         $this->assertEquals(301, $response->getStatusCode());
-
         $this->assertEquals(
             Director::absoluteURL($redirect->To),
             $response->getHeader('Location')
         );
     }
 
-    public function testHanldeRootRedirectWithExtension(): void
+    public function testHandleRootRedirectWithExtension(): void
     {
         $redirect = $this->objFromFixture(RedirectedURL::class, 'redirect-root-extension');
         $response = $this->get($redirect->FromBase);
-        $this->assertEquals(301, $response->getStatusCode());
 
+        $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals(
             Director::absoluteURL($redirect->To),
             $response->getHeader('Location')
@@ -44,8 +43,8 @@ class RedirectedURLHandlerTest extends FunctionalTest
 
     public function testHandleURLRedirectionWithQueryString(): void
     {
-        $response = $this->get('query-test-with-query-string?foo=bar');
         $expected = $this->objFromFixture(RedirectedURL::class, 'redirect-with-query');
+        $response = $this->get('query-test-with-query-string?foo=bar');
 
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals(

--- a/tests/Extension/RedirectedURLHandlerTest.yml
+++ b/tests/Extension/RedirectedURLHandlerTest.yml
@@ -4,11 +4,11 @@ SilverStripe\RedirectedURLs\Model\RedirectedURL:
     To: /site-info/log-in/
   redirect-with-query:
     FromBase: /query-test-with-query-string
-    FromQueryString: foo=bar
+    FromQuerystring: foo=bar
     To: /query-test-foo
   redirect-with-longer-query:
     FromBase: /query-test-with-query-string
-    FromQueryString: "foo=bar&baz=qux"
+    FromQuerystring: "foo=bar&baz=qux"
   redirect-root-extension:
     FromBase: /some_old_page.html
     To: /newpage

--- a/tests/Model/RedirectedURLTest.php
+++ b/tests/Model/RedirectedURLTest.php
@@ -26,7 +26,7 @@ class RedirectedURLTest extends SapphireTest
         parent::setUp();
     }
 
-    public function testSetFromQueryString(): void
+    public function testSetFromQuerystring(): void
     {
         $val = '/test/url?subpage=12';
 
@@ -62,16 +62,6 @@ class RedirectedURLTest extends SapphireTest
         $this->assertEquals($val . '?subpage=12', $this->model->getFrom());
     }
 
-    public function testSetFromBase(): void
-    {
-        $val = 'test/url';
-
-        $this->model->setFromBase($val);
-
-        $this->assertEquals('/test/url', $this->model->getFrom());
-    }
-
-
     public function testFindByFromNoSlash(): void
     {
         // Without preceding slash
@@ -101,7 +91,7 @@ class RedirectedURLTest extends SapphireTest
         $this->assertEquals('/test/target', $redirect->To);
     }
 
-    public function testFindByFromQueryString(): void
+    public function testFindByFromQuerystring(): void
     {
         // Search for subpage
         $redirect = $this->model->findByFrom('/test/url-2?subpage=12');
@@ -122,7 +112,7 @@ class RedirectedURLTest extends SapphireTest
     {
         $redirect = $this->objFromFixture(RedirectedURL::class, 'redirect3');
 
-        $this->assertEquals('page-1/', $redirect->Link());
+        $this->assertEquals('page-1', $redirect->Link());
     }
 
     public function testLinkToAsset(): void


### PR DESCRIPTION
## New major

This will need to be tagged as version `^3`. I have created a new `2` branch, which we can use for ongoing support for Silverstripe 4.

## Removal of setter methods

Removed the following methods from `RedirectedURL`:

* `setFromBase()` (setter for field `FromBase`)
* `setFromQuerystring()` (setter for field `FromQuerystring`)

Replaced them with a more explicit `onBeforeWrite()`. For me, this removes some of the "magic" that is not obvious to anyone (including me) who is not familiar with the setter/getter magic method paradigm.

There is also a regression in Silverstripe 5:
https://github.com/silverstripe/silverstripe-framework/issues/10707

The removal of these methods means that we are not going to be affected by this.

## Methods removed

`RedirectedURLHandler` had two classes that were not being directly used, and can instead be directly accessed through the new `Support` classes.

* `arrayToLowercase()`
* `getRedirectCode()`

## Updated API

Updated property and return types wherever possible.

## Trailing slashes

Trailing slashes for URLs is now configurable in Silverstripe 5, and the default is that they are disabled. Updated unit tests accordingly.